### PR TITLE
Use 'main' branch for pythondata-cpu-marocchino.

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -102,7 +102,7 @@ git_repos = {
     "pythondata-cpu-blackparrot":  GitRepo(url="https://github.com/litex-hub/"),
     "pythondata-cpu-cv32e40p":     GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-ibex":         GitRepo(url="https://github.com/litex-hub/", clone="recursive", sha1=0xd3d53df),
-    "pythondata-cpu-marocchino":   GitRepo(url="https://github.com/litex-hub/"),
+    "pythondata-cpu-marocchino":   GitRepo(url="https://github.com/litex-hub/", branch="main"),
 }
 
 # Installs -----------------------------------------------------------------------------------------


### PR DESCRIPTION
This avoids a Python exception in litex_setup.py --update due to no master branch.